### PR TITLE
Fixes #42 increment/decrement whitespace bug

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -895,11 +895,13 @@ export class Packer {
                     // - `/.../ in b` vs. `/.../in b`; also applies to other names or number literals
                     //   starting with digits, but only `in` and `instanceof` are possible in the valid JS.
                     // - `a + + b` vs. `a ++ b`
+                    // - `a + ++ b` vs. `a +++ b`
                     // - `a - - b` vs. `a -- b`
+                    // - `a - -- b` vs. `a --- b`
                     // - short HTML comments only recognized in web browsers:
                     //   - `a < ! --b` vs. `a <!--b`
                     //   - `a-- > b` vs. `a-->b`
-                    (prevToken.value + ' ' + token.value).match(/^\/ \/|\/ in(?:stanceof)?$|^(?:\+ \+|- -|! --|-- >)$/)
+                    (prevToken.value + ' ' + token.value).match(/^\/ \/|\/ in(?:stanceof)?$|^(?:\+ \+\+?|- --?|! --|-- >)$/)
                 )) {
                     if (prevToken.abbr) {
                         if (token.abbr) {

--- a/test.mjs
+++ b/test.mjs
@@ -379,6 +379,8 @@ test('prepareJs without abbrs', t => {
     t.is(prepare(`switch (3) { case .3: ; }`), `switch(3){case.3:;}`);
     t.is(prepare(`switch (3) { case ㅎ: ; }`), `switch(3){case \\u314e:;}`);
     t.is(prepare(`for (const a of $tuffs) {}`), `for(const a of $tuffs){}`);
+    t.is(prepare(`a + ++b`), `a+ ++b`);
+    t.is(prepare(`a - --b`), `a- --b`);
 });
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Handles these whitespace cases:

- `a + ++b` vs. `a +++b`
- `a - --b` vs. `a ---b`